### PR TITLE
chore: update in-repo references from master to main

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,7 +10,7 @@ updates:
     directory: "/"
     schedule:
       interval: "monthly"
-    target-branch: "master"
+    target-branch: "main"
     open-pull-requests-limit: 0
 
   # Keep the GitHub Actions (pinned to commit SHAs) up to date. Dependabot
@@ -20,7 +20,7 @@ updates:
     directory: "/"
     schedule:
       interval: "monthly"
-    target-branch: "master"
+    target-branch: "main"
     groups:
       github-actions:
         patterns:
@@ -40,7 +40,7 @@ updates:
     directory: "/"
     schedule:
       interval: "monthly"
-    target-branch: "master"
+    target-branch: "main"
     groups:
       pip:
         patterns:

--- a/.github/workflows/docs-snapshot.yml
+++ b/.github/workflows/docs-snapshot.yml
@@ -1,11 +1,11 @@
 name: Docs Snapshot
 
-# Publish the "snapshot" docs version (current master) to GitHub Pages.
+# Publish the "snapshot" docs version (current main) to GitHub Pages.
 # Releases are published by docs-release.yml.
 
 on:
   push:
-    branches: [master]
+    branches: [main]
     paths:
       - 'docs/**'
       - 'mkdocs.yml'

--- a/README.md
+++ b/README.md
@@ -21,8 +21,8 @@ More information can be found in the [documentation](https://smarkwal.github.io/
 [![Downloads](https://img.shields.io/github/downloads/smarkwal/jarhc/total?label=Downloads)](https://github.com/smarkwal/jarhc/releases)
 
 [![Build](https://github.com/smarkwal/jarhc/actions/workflows/build.yml/badge.svg)](https://github.com/smarkwal/jarhc/actions/workflows/build.yml)
-[![Tests](https://img.shields.io/sonar/tests/smarkwal_jarhc/master?label=Tests&server=https%3A%2F%2Fsonarcloud.io)](https://sonarcloud.io/component_measures?id=smarkwal_jarhc&metric=test_success_density&selected=smarkwal_jarhc%3Asrc%2Ftest%2Fjava%2Forg%2Fjarhc)
-[![Coverage](https://img.shields.io/sonar/coverage/smarkwal_jarhc/master?label=Coverage&server=https%3A%2F%2Fsonarcloud.io)](https://sonarcloud.io/component_measures?id=smarkwal_jarhc&metric=coverage&view=list)
-[![Quality](https://img.shields.io/sonar/quality_gate/smarkwal_jarhc/master?label=Quality&server=https%3A%2F%2Fsonarcloud.io)](https://sonarcloud.io/dashboard?id=smarkwal_jarhc)
+[![Tests](https://img.shields.io/sonar/tests/smarkwal_jarhc/main?label=Tests&server=https%3A%2F%2Fsonarcloud.io)](https://sonarcloud.io/component_measures?id=smarkwal_jarhc&metric=test_success_density&selected=smarkwal_jarhc%3Asrc%2Ftest%2Fjava%2Forg%2Fjarhc)
+[![Coverage](https://img.shields.io/sonar/coverage/smarkwal_jarhc/main?label=Coverage&server=https%3A%2F%2Fsonarcloud.io)](https://sonarcloud.io/component_measures?id=smarkwal_jarhc&metric=coverage&view=list)
+[![Quality](https://img.shields.io/sonar/quality_gate/smarkwal_jarhc/main?label=Quality&server=https%3A%2F%2Fsonarcloud.io)](https://sonarcloud.io/dashboard?id=smarkwal_jarhc)
 
 [![Issues](https://img.shields.io/github/issues/smarkwal/jarhc?label=Issues)](https://github.com/smarkwal/jarhc/issues)

--- a/docs/project.md
+++ b/docs/project.md
@@ -156,14 +156,14 @@ code runs. The corresponding version is noted in a comment on the same line:
 uses: actions/checkout@<commit-sha> # v7.0.0
 ```
 
-These pins are kept up to date by Dependabot (see [`.github/dependabot.yml`](https://github.com/smarkwal/jarhc/blob/master/.github/dependabot.yml)).
+These pins are kept up to date by Dependabot (see [`.github/dependabot.yml`](https://github.com/smarkwal/jarhc/blob/main/.github/dependabot.yml)).
 
 ### Documentation
 
 The documentation is automatically built and published to GitHub Pages:
 
-1. On every push to the `master` branch by the GitHub workflow [Docs Snapshot](https://github.com/smarkwal/jarhc/blob/master/.github/workflows/docs-snapshot.yml).
-2. On every release by the GitHub workflow [Docs Release](https://github.com/smarkwal/jarhc/blob/master/.github/workflows/docs-release.yml).
+1. On every push to the `main` branch by the GitHub workflow [Docs Snapshot](https://github.com/smarkwal/jarhc/blob/main/.github/workflows/docs-snapshot.yml).
+2. On every release by the GitHub workflow [Docs Release](https://github.com/smarkwal/jarhc/blob/main/.github/workflows/docs-release.yml).
 
 To test the documentation locally before publishing, run:
 

--- a/jarhc/build.gradle.kts
+++ b/jarhc/build.gradle.kts
@@ -437,5 +437,5 @@ fun getGitBranchName(): String {
 }
 
 fun getGitBranchTarget(branchName: String): String {
-    return "master"
+    return "main"
 }

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -5,7 +5,7 @@ site_author: Stephan Markwalder
 
 repo_url: https://github.com/smarkwal/jarhc
 repo_name: smarkwal/jarhc
-edit_uri: edit/master/docs/
+edit_uri: edit/main/docs/
 
 copyright: JarHC - JAR Health Check | <a href="https://jarhc.org">jarhc.org</a>
 


### PR DESCRIPTION
**Phase 1** of #366 — update only the files that reference our own default branch. This PR is ready to review now but should be **merged immediately after** the GitHub rename (Phase 2) and SonarCloud rename (Phase 3), so triggers, Dependabot target, and Sonar target line up with minimal gap.

## Changes
- `.github/dependabot.yml` — `target-branch` for gradle, github-actions, pip (3×)
- `.github/workflows/docs-snapshot.yml` — push trigger branch + header comment
- `mkdocs.yml` — `edit_uri`
- `docs/project.md` — `blob/master` links and "master branch" wording
- `README.md` — SonarCloud Tests/Coverage/Quality badges
- `jarhc/build.gradle.kts` — `getGitBranchTarget()`, which drives `sonar.branch.target` / `sonar.newCode.referenceBranch`

## Intentionally NOT touched (false positives)
Third-party URLs in generated reports (`docs/examples/**`, `docs/jarhc-report.*`), expected-output fixtures (`jarhc-release-tests/.../reports/**`), and POM fixtures (`maven-proxy-server/repo/**/*.pom`) — e.g. `stleary/JSON-java/blob/master/...`.

> [!WARNING]
> The README SonarCloud badges only resolve once SonarCloud's main branch is renamed (Phase 3), and `getGitBranchTarget()` must match SonarCloud's renamed branch or new-code analysis breaks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)