### PR TITLE
docs/expand-agents-md

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -25,12 +25,6 @@ updates:
       github-actions:
         patterns:
           - "*"
-    ignore:
-      # Stay on gradle/actions v5: v6 moves caching into the proprietary
-      # gradle-actions-caching component (Gradle commercial Terms of Use).
-      # Bump to v6 deliberately, not automatically.
-      - dependency-name: "gradle/actions"
-        update-types: ["version-update:semver-major"]
 
   # Python docs toolchain. The lockfile is a pip-compile output, which
   # Dependabot supports: it regenerates the hash-pinned requirements.txt

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,55 @@
 # AGENTS.md
 
-Conventions for working in the JarHC repository.
+Conventions for working in the JarHC repository. Keep this file tight: short bullet
+lists of facts, minimal prose. The Documentation section is the deliberate
+exception, it is a detailed style guide. Preserve both styles when editing.
+
+## Workflow
+
+- Pushes to `main` are blocked by GitHub.
+- All changes go through a branch and a pull request.
+- GitHub Copilot reviews every pull request.
+- Leave `dependabot/...` branches to Dependabot.
+
+## Project layout
+
+- Multi-project build: root + three subprojects.
+  - `jarhc` — the tool itself (library and command line application).
+  - `jarhc-release-tests` — release and integration tests (Testcontainers, Docker).
+  - `jarhc-docs-tasks` — documentation helper tasks (Playwright).
+- `website/` — MkDocs documentation sources (`mkdocs.yml`, `docs/`).
+- Add the Apache 2.0 license header to new source files.
+
+## Java and Gradle versions
+
+- `jarhc` bytecode: Java 11.
+- Build runs on: Java 17 (subprojects fail fast on anything older).
+- CI installs both JDK 11 and 17.
+- Gradle wrapper: 9.6.1.
+
+## Dependencies
+
+- Versions live in the version catalog: `gradle/libs.versions.toml`.
+- Dependency locking is enabled; lockfiles are committed.
+- Check for updates: `./gradlew dependencyUpdates`.
+- After changing any version, refresh the lockfiles: `./gradlew updateGradleLockfiles --write-locks`.
+- Dependabot runs monthly:
+  - GitHub Actions: grouped into one PR; bumps the SHA and the `# vX.Y.Z` comment.
+  - Python docs toolchain (`website/`): grouped into one PR.
+  - Gradle dependencies: intentionally disabled (`open-pull-requests-limit: 0`); update manually.
+  - `gradle/actions` major bumps are not auto-applied (Dependabot ignores semver-major); bump deliberately.
+
+## Building
+
+- `./gradlew :jarhc:build` — compile, unit tests, reports, artifacts (this is what CI runs).
+- Requires Java 17 to run Gradle.
+- `jarhc-release-tests` needs Docker; it is not part of the default build.
+- `:sonar` needs a token (`SONAR_TOKEN` env var or `sonar.token` system property). It runs automatically on CI for pushes (not Dependabot branches); run it locally (with a token in your Gradle settings) only for a reason such as a Sonar plugin update, a Sonar config change, or checking Sonar compatibility with a new Java or Gradle version.
+
+## GitHub Actions
+
+- Pin every action by full commit SHA with a `# vX.Y.Z` comment.
+- Keep `cache-provider: basic` on `gradle/actions` v6+ to keep the free GitHub Actions cache (v6 made the default caching a commercial component).
 
 ## Documentation
 
@@ -122,3 +171,40 @@ whose `sources` changed (by git commit date) after their `last_reviewed` date:
 Run it before a release, or after changing analyzers, command line options, or
 dependencies, to find pages that need a re-review. See the skill for the
 page-by-page review and update workflow.
+
+## Categories
+
+Shared terms, used both as commit message prefixes and as branch name categories:
+
+- `project` — project setup: dependency and tooling upgrades, version changes, build configuration
+- `feature` — add a new feature
+- `bugfix` — fix a bug
+- `code` — refactor existing code
+- `tests` — add or change tests
+- `docs` — update documentation
+- `ci` — continuous integration, such as GitHub Actions workflows
+- `release` — release activities
+- `hotfix` — urgent fix
+
+## Commit messages
+
+- Always start the subject with a category prefix: a term from the list above, capitalized, followed by a colon. Example: "Project: Upgrade SonarQube plugin".
+- After the prefix, use the imperative mood with a capitalized first word.
+- Combine closely related changes as separate sentences in the subject.
+- Add a body (after a blank line) only when the change needs a rationale; state the why, not the diff.
+
+## Branch names
+
+- `<category>/<kebab-case-description>`. Example: `project/upgrade-gradle`.
+- Leave `dependabot/...` branches to Dependabot.
+
+## Pull request names
+
+- Same as the branch name.
+
+## Handling Copilot comments
+
+- Do not apply Copilot's suggestions automatically.
+- Review each comment, plus any "comments suppressed due to low confidence" note, and decide whether it is worth fixing or a false positive.
+- Propose how a fix would look and wait for the user's approval before changing anything.
+- Once approved: apply the fix, run the build to test it, commit and push, then reply to the comment and mark the thread resolved.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -37,7 +37,6 @@ exception, it is a detailed style guide. Preserve both styles when editing.
   - GitHub Actions: grouped into one PR; bumps the SHA and the `# vX.Y.Z` comment.
   - Python docs toolchain (`website/`): grouped into one PR.
   - Gradle dependencies: intentionally disabled (`open-pull-requests-limit: 0`); update manually.
-  - `gradle/actions` major bumps are not auto-applied (Dependabot ignores semver-major); bump deliberately.
 
 ## Building
 


### PR DESCRIPTION
Bring the repository conventions and their documentation in sync.

## AGENTS.md
Expand `AGENTS.md` with the project's working conventions in the tight, list-first style:
workflow, project layout, Java and Gradle versions, dependencies, building, GitHub Actions,
categories, commit messages, branch names, pull request names, and handling of Copilot
comments. The existing documentation style guide is preserved verbatim.

## dependabot.yml
Remove the obsolete `gradle/actions` major-version ignore rule and its comment. The workflows
already run `gradle/actions` v6 with `cache-provider: basic`, so pinning Dependabot to v5 no
longer reflects reality. Dependabot will propose `gradle/actions` major bumps again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)