### PR TITLE
code/resolve-git-worktree-pointer

### DIFF
--- a/jarhc/build.gradle.kts
+++ b/jarhc/build.gradle.kts
@@ -430,7 +430,13 @@ tasks.withType<GenerateModuleMetadata> {
 // helper functions ------------------------------------------------------------
 
 fun getGitBranchName(): String {
-    val file = project.rootDir.resolve(".git/HEAD")
+    var gitDir = project.rootDir.resolve(".git")
+    // In worktrees and submodules, .git is a file: "gitdir: <path>"
+    if (gitDir.isFile) {
+        val gitdir = gitDir.readText(Charsets.UTF_8).trim().removePrefix("gitdir: ")
+        gitDir = project.rootDir.resolve(gitdir)
+    }
+    val file = gitDir.resolve("HEAD")
     if (file.isFile) {
         val content = file.readText(Charsets.UTF_8).trim()
         if (content.startsWith("ref: refs/heads/")) {


### PR DESCRIPTION
## Summary

Makes `getGitBranchName()` in `jarhc/build.gradle.kts` work when the build runs from a Git worktree or submodule.

In those cases `.git` is a *file* (`gitdir: <path>`) rather than a directory, so `.git/HEAD` does not exist and the helper threw `GradleException("Git branch name not found.")`. The fix follows the `gitdir:` pointer to the real git directory before reading `HEAD`.

## Context

Mirrors the same fix applied to the JarHC Gradle Plugin repo (raised there by Copilot review). Impact is low — the helper is only evaluated when Sonar properties are computed, so normal builds and CI (plain clone) were unaffected; only a local `./gradlew :jarhc:sonar` from a worktree would have thrown. Applied here to keep the two repos' helpers in sync.

## Verification

- Build script configures successfully (`./gradlew :jarhc:help`).
- Confirmed the pointer-following logic resolves `HEAD` via the `gitdir:` file in a worktree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)