### PR TITLE
project/cleanup-build-scripts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,7 +28,6 @@ bin/
 *.jfr
 
 # user-specific files
-gradle.user.properties
 *.gpg
 .java-version
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 import org.gradle.plugins.ide.idea.model.IdeaLanguageLevel
-import java.util.*
 
 plugins {
 
@@ -38,16 +37,6 @@ allprojects {
     // lock all dependency configurations in every project ---------------------
     dependencyLocking {
         lockAllConfigurations()
-    }
-
-    // load user-specific properties -------------------------------------------
-    val userPropertiesFile = file("${rootDir}/gradle.user.properties")
-    if (userPropertiesFile.exists()) {
-        val userProperties = Properties()
-        userProperties.load(userPropertiesFile.inputStream())
-        userProperties.forEach {
-            project.ext.set(it.key.toString(), it.value)
-        }
     }
 
 }

--- a/jarhc/build.gradle.kts
+++ b/jarhc/build.gradle.kts
@@ -79,7 +79,7 @@ gradle.taskGraph.whenReady {
 
 // flag to skip tests
 // command line option: -Pskip.tests
-val skipTests: Boolean = project.hasProperty("skip.tests")
+val skipTests = providers.gradleProperty("skip.tests").isPresent
 
 // constants -------------------------------------------------------------------
 
@@ -368,10 +368,10 @@ val jarApp = tasks.register<Jar>("jar-app") {
 }
 
 // common settings for all test tasks
-tasks.withType<Test> {
+tasks.withType<Test>().configureEach {
 
     // skip tests if property "skip.tests" is set
-    onlyIf { !skipTests }
+    if (skipTests) enabled = false
 
     // disable up-to-date check -> re-run tests every time
     outputs.upToDateWhen { false }


### PR DESCRIPTION
Clean up the Gradle build scripts by removing an unused mechanism and modernizing the test-skip flag.

## Remove the `gradle.user.properties` loader
The root build read an optional `gradle.user.properties` and injected its entries as project
extra properties. Nothing in the build depends on it: personal and release credentials live in
`~/.gradle/gradle.properties`, and the `jarhc.*` test overrides are read via
`gradlePropertiesPrefixedBy(...)`, which does not see extra properties anyway. Removed the loader,
its now-unused `import java.util.*`, and the obsolete `.gitignore` entry.

## Modernize the `skip.tests` flag
Reworked the `-Pskip.tests` handling to be configuration-cache friendly:

- Read the flag via `providers.gradleProperty("skip.tests")` instead of the legacy
  `project.hasProperty(...)`.
- Skip tests by setting `enabled = false` at configuration time instead of an execution-time
  `onlyIf { !skipTests }`, which captured script state and is not configuration-cache compatible.
- Configure the test tasks lazily via `withType<Test>().configureEach { }`.

Behavior is unchanged: `-Pskip.tests` still skips the test tasks. This also removes one of the
known configuration-cache blockers in the build; full configuration-cache compliance remains a
separate, larger task.

🤖 Generated with [Claude Code](https://claude.com/claude-code)