### PR TITLE
docs/point-readme-to-jarhc-org

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ It is available as [Gradle plugin](https://github.com/smarkwal/jarhc-gradle-plug
 java -jar jarhc-app.jar [options] <artifact> [<artifact>]*
 ```
 
-More information can be found in the [documentation](https://smarkwal.github.io/jarhc/).
+More information can be found in the [documentation](https://jarhc.org/).
 
 ![JarHC Logo](website/docs/assets/jarhc-logo.png)
 


### PR DESCRIPTION
## Summary

The README's only documentation link pointed to the retired `smarkwal.github.io/jarhc/` GitHub Pages domain. This updates it to the stable `https://jarhc.org/` root (which redirects to the current version).

## Why

Part of improving search-engine discovery of the documentation. The README link is one of the highest-authority backlinks to the docs, so it should point at the canonical site rather than the old domain. The bare root is used deliberately: the `/latest/` path is a mike/mkdocs implementation detail that could change if the documentation tooling changes.

Related: the repo "Website" field was set to `https://jarhc.org/` directly in the repo settings (outside this PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)