### PR TITLE
CI: Enable SonarCloud pull request decoration

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,7 +1,13 @@
 name: Build
 
+# Branch analysis runs on the main branch (the baseline); pull requests are
+# analyzed in pull request mode so SonarCloud decorates the PR. Feature branches
+# are built and analyzed through their pull request, not on every push.
 on:
   push:
+    branches:
+      - main
+  pull_request:
   workflow_dispatch:
     inputs:
       additionalGradleOptions:
@@ -16,7 +22,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-      PUSH_GRADLE_OPTIONS: ''
+      SONAR_GRADLE_OPTIONS: ''
 
     steps:
 
@@ -33,18 +39,32 @@ jobs:
           11
           17
 
+    # Determine the Sonar analysis mode:
+    #  - push to main: branch analysis (the baseline).
+    #  - same-repo, non-dependabot pull request: pull request analysis (decorates the PR).
+    #  - forks and dependabot: no SONAR_TOKEN is available, so Sonar is skipped.
+    - name: Configure Sonar analysis
+      env:
+        EVENT_NAME: ${{ github.event_name }}
+        PR_SAME_REPO: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
+        PR_NUMBER: ${{ github.event.pull_request.number }}
+        PR_HEAD_REF: ${{ github.head_ref }}
+        PR_BASE_REF: ${{ github.base_ref }}
+      run: |
+        if [ "$EVENT_NAME" = "push" ]; then
+          echo "SONAR_GRADLE_OPTIONS=sonar" >> "$GITHUB_ENV"
+        elif [ "$EVENT_NAME" = "pull_request" ] && [ "$PR_SAME_REPO" = "true" ] && [ "${PR_HEAD_REF#dependabot/}" = "$PR_HEAD_REF" ]; then
+          echo "SONAR_GRADLE_OPTIONS=sonar -Dsonar.pullrequest.key=$PR_NUMBER -Dsonar.pullrequest.branch=$PR_HEAD_REF -Dsonar.pullrequest.base=$PR_BASE_REF" >> "$GITHUB_ENV"
+        fi
+
     - name: Restore Sonar Cache
       uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
-      if: ${{ github.event_name == 'push' && !startsWith(github.ref_name, 'dependabot/') }}
+      if: ${{ env.SONAR_GRADLE_OPTIONS != '' }}
       with:
         path: /home/runner/.sonar/cache
         key: sonar-cache-${{ runner.os }}-${{ hashFiles('**/*.gradle*', 'gradle/libs.versions.toml') }}
         restore-keys: |
           sonar-cache-${{ runner.os }}-
-
-    - name: Set Push Gradle options
-      if: ${{ github.event_name == 'push' && !startsWith(github.ref_name, 'dependabot/') }}
-      run: echo "PUSH_GRADLE_OPTIONS=sonar" >> $GITHUB_ENV
 
     - name: Setup Gradle
       uses: gradle/actions/setup-gradle@3f131e8634966bd73d06cc69884922b02e6faf92 # v6.2.0
@@ -53,7 +73,7 @@ jobs:
         cache-read-only: false
 
     - name: Build with Gradle
-      run: './gradlew --no-daemon :jarhc:build ${{ env.PUSH_GRADLE_OPTIONS }} ${{ github.event.inputs.additionalGradleOptions }}'
+      run: './gradlew --no-daemon :jarhc:build ${{ env.SONAR_GRADLE_OPTIONS }} ${{ github.event.inputs.additionalGradleOptions }}'
 
     - name: Upload reports
       uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -54,7 +54,7 @@ jobs:
         if [ "$EVENT_NAME" = "push" ]; then
           echo "SONAR_GRADLE_OPTIONS=sonar" >> "$GITHUB_ENV"
         elif [ "$EVENT_NAME" = "pull_request" ] && [ "$PR_SAME_REPO" = "true" ] && [ "${PR_HEAD_REF#dependabot/}" = "$PR_HEAD_REF" ]; then
-          echo "SONAR_GRADLE_OPTIONS=sonar -Dsonar.pullrequest.key=$PR_NUMBER -Dsonar.pullrequest.branch=$PR_HEAD_REF -Dsonar.pullrequest.base=$PR_BASE_REF" >> "$GITHUB_ENV"
+          printf 'SONAR_GRADLE_OPTIONS=sonar -Dsonar.pullrequest.key=%q -Dsonar.pullrequest.branch=%q -Dsonar.pullrequest.base=%q\n' "$PR_NUMBER" "$PR_HEAD_REF" "$PR_BASE_REF" >> "$GITHUB_ENV"
         fi
 
     - name: Restore Sonar Cache

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,6 +10,7 @@ exception, it is a detailed style guide. Preserve both styles when editing.
 - All changes go through a branch and a pull request.
 - Never force-push.
 - GitHub Copilot reviews every pull request.
+- SonarCloud analyzes every pull request and decorates it with findings.
 - Leave `dependabot/...` branches to Dependabot.
 
 ## Project layout
@@ -208,3 +209,11 @@ Shared terms, used both as commit message prefixes and as branch name categories
 - Review each comment, plus any "comments suppressed due to low confidence" note, and decide whether it is worth fixing or a false positive.
 - Propose how a fix would look and wait for the user's approval before changing anything.
 - Once approved: apply the fix, run the build to test it, commit and push, then reply to the comment and mark the thread resolved.
+
+## Handling SonarCloud findings
+
+- Do not apply SonarCloud's findings automatically.
+- Review each finding and decide whether it is worth fixing or a false positive.
+- The details (rule, file, line, message) can be read from the SonarCloud API or the pull request annotations.
+- Propose how a fix would look and wait for the user's approval before changing anything.
+- Once approved: apply the fix, run the build to test it, then commit and push.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -207,6 +207,7 @@ Shared terms, used both as commit message prefixes and as branch name categories
 
 - Do not apply Copilot's suggestions automatically.
 - Review each comment, plus any "comments suppressed due to low confidence" note, and decide whether it is worth fixing or a false positive.
+- Evaluate Copilot's own proposed fix on its merits before offering an alternative. If you propose a different fix, present Copilot's suggestion alongside it and explain why yours is better; do not silently replace it.
 - Propose how a fix would look and wait for the user's approval before changing anything.
 - Once approved: apply the fix, run the build to test it, commit and push, then reply to the comment and mark the thread resolved.
 

--- a/jarhc/build.gradle.kts
+++ b/jarhc/build.gradle.kts
@@ -151,9 +151,6 @@ java {
     // Maven Central publish plugin (mavenPublishing block below).
 }
 
-val sonarBranchName: String = getGitBranchName()
-val sonarBranchTarget: String = getGitBranchTarget(sonarBranchName)
-
 sonar {
     // documentation: https://docs.sonarqube.org/latest/analyzing-source-code/scanners/sonarscanner-for-gradle/
 
@@ -164,15 +161,24 @@ sonar {
         property("sonar.organization", "smarkwal")
         property("sonar.projectKey", "smarkwal_jarhc")
 
-        // Git branch
-        property("sonar.branch.name", sonarBranchName)
+        // In pull request analysis mode the build workflow passes the
+        // sonar.pullrequest.* properties on the command line. Branch properties
+        // must not be set in that case: SonarScanner rejects mixing branch and
+        // pull request analysis.
+        if (System.getProperty("sonar.pullrequest.key") == null) {
 
-        // target Git branch for merge
-        if (sonarBranchTarget != sonarBranchName) {
-            // https://docs.sonarsource.com/sonarqube-cloud/enriching/branch-analysis-setup/
-            property("sonar.branch.target", sonarBranchTarget)
-            // https://docs.sonarsource.com/sonarqube-server/latest/analyzing-source-code/analysis-parameters/
-            property("sonar.newCode.referenceBranch", sonarBranchTarget)
+            // Git branch
+            val sonarBranchName = getGitBranchName()
+            val sonarBranchTarget = getGitBranchTarget(sonarBranchName)
+            property("sonar.branch.name", sonarBranchName)
+
+            // target Git branch for merge
+            if (sonarBranchTarget != sonarBranchName) {
+                // https://docs.sonarsource.com/sonarqube-cloud/enriching/branch-analysis-setup/
+                property("sonar.branch.target", sonarBranchTarget)
+                // https://docs.sonarsource.com/sonarqube-server/latest/analyzing-source-code/analysis-parameters/
+                property("sonar.newCode.referenceBranch", sonarBranchTarget)
+            }
         }
 
         // paths to test sources and test classes

--- a/jarhc/build.gradle.kts
+++ b/jarhc/build.gradle.kts
@@ -165,7 +165,7 @@ sonar {
         // sonar.pullrequest.* properties on the command line. Branch properties
         // must not be set in that case: SonarScanner rejects mixing branch and
         // pull request analysis.
-        if (System.getProperty("sonar.pullrequest.key") == null) {
+        if (System.getProperty("sonar.pullrequest.key").isNullOrBlank()) {
 
             // Git branch
             val sonarBranchName = getGitBranchName()


### PR DESCRIPTION
Closes #380.

## What

Make SonarCloud feedback visible directly on pull requests via **pull request decoration** (summary comment, Quality Gate check, and inline annotations on changed lines), instead of results living only under the branch in the SonarCloud UI.

## Changes

**`.github/workflows/build.yml`**
- Trigger on `pull_request` in addition to `push`, and restrict `push` to `main`. Branch analysis now runs once on `main` as the baseline; feature branches are built and analyzed through their pull request. This is the SonarCloud-recommended split and avoids analyzing a branch twice per push.
- A new *Configure Sonar analysis* step decides the mode:
  - push to `main` → `sonar` (branch analysis).
  - same-repo, non-dependabot pull request → `sonar -Dsonar.pullrequest.key/branch/base=…` (PR analysis).
  - forks and dependabot → no `SONAR_TOKEN`, so Sonar is skipped and only the build runs.
- PR values are passed through an `env:` mapping (no shell interpolation into `run:`).

**`jarhc/build.gradle.kts`**
- The `sonar { }` block skips the branch properties (`sonar.branch.name`, `sonar.branch.target`, `sonar.newCode.referenceBranch`) when `sonar.pullrequest.key` is present, because SonarScanner rejects mixing branch and pull request analysis.

## Notes

- `pull_request` events from forks and dependabot do not receive repository secrets, so `SONAR_TOKEN` is unavailable there by design; those runs build without Sonar. `pull_request_target` is intentionally not used (token-exfiltration risk).
- PR decoration is automatic for a project bound to SonarCloud via the GitHub App (as `smarkwal_jarhc` is). **This PR itself is the first check that decoration actually appears.**
- The optional Quality Gate hard-merge-gate follow-up from the issue is left out of this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)